### PR TITLE
add  :Z suffix option to docker --volume

### DIFF
--- a/src/main/kotlin/com/parmet/buf/gradle/BufPlugin.kt
+++ b/src/main/kotlin/com/parmet/buf/gradle/BufPlugin.kt
@@ -227,7 +227,7 @@ class BufPlugin : Plugin<Project> {
 private fun Project.baseDockerArgs(ext: BufExtension) =
     listOf(
         "run",
-        "--volume", "$bufbuildDir:/workspace",
+        "--volume", "$bufbuildDir:/workspace:Z",
         "--workdir", "/workspace",
         "bufbuild/buf:${ext.toolVersion}"
     )


### PR DESCRIPTION
This allows to run this Gradle plugin on Linux distributions with SELinux, such as https://getfedora.org, RHEL, etc.

#21 has full background.